### PR TITLE
Cleanup old code & add some.

### DIFF
--- a/GameData/CCTV/Parts/cam/cam.cfg
+++ b/GameData/CCTV/Parts/cam/cam.cfg
@@ -46,7 +46,7 @@
 	}
 }
 
-@PART[remotecam]:NEEDS[BobsPanicBox]:FINAL
+@PART[cam]:NEEDS[BobsPanicBox]:FINAL
 {
 	-MODULE[Module_BobsExplosionDetector] {}
 }

--- a/GameData/CCTV/Parts/cam/cam.cfg
+++ b/GameData/CCTV/Parts/cam/cam.cfg
@@ -3,15 +3,9 @@
 	name = cam
 	module = Part
 	author = Lunatics
-	
-	MODEL
-	{
-		//model=lunatics/cam/cam
-		model=CCTV/Parts/cam/cam
-	}
-	
+
 	node_attach = 0.0, 0.0, 0.07, 0.0, 0.0, -1.0
-	
+
 	TechRequired = advExploration
 	entryCost = 3200
 	cost = 3300
@@ -21,7 +15,7 @@
 	manufacturer = Lunatic Aeronautics
 	description = A brand new (scratches are design elements, not signs of being used) security camera
 	attachRules = 0,1,0,0,1
-	
+
 	// --- standard part parameters ---
 	mass = 0.005
 	dragModelType = default
@@ -30,24 +24,19 @@
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 3200
-	
+
+	MODEL
+	{
+		model=CCTV/Parts/cam/cam
+	}
+
 	MODULE
 	{
 		name = cccam
 		speed = 30
 		cameraBody = cambody
 	}
-	MODULE
-	{
-		name = KASModuleGrab
-		evaPartPos = (0.0, 0.0, 0.0)
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize = 1
-		attachOnPart = True
-		attachOnEva = False
-		attachOnStatic = True
-	}
+
 	MODULE
 	{
 		name = JSIExternalCameraSelector
@@ -55,4 +44,9 @@
 		rotateCamera = 0,0,0
 		cameraIDPrefix = ExtCam
 	}
+}
+
+@PART[remotecam]:NEEDS[BobsPanicBox]:FINAL
+{
+	-MODULE[Module_BobsExplosionDetector] {}
 }

--- a/GameData/CCTV/Parts/monitor/monitor.cfg
+++ b/GameData/CCTV/Parts/monitor/monitor.cfg
@@ -3,15 +3,9 @@ PART
 	name = monitor
 	module = Part
 	author = Lunatics
-	
-	MODEL
-	{
-		//model = lunatics/monitor/monitor
-		model = CCTV/Parts/monitor/monitor
-	}
-	
+
 	node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
-	
+
 	TechRequired = advExploration
 	entryCost = 3200
 	cost = 3300
@@ -21,7 +15,7 @@ PART
 	manufacturer = Lunatic Aeronautics
 	description = Lunatics' best ever TV
 	attachRules = 0,1,0,0,1
-	
+
 	// --- standard part parameters ---
 	mass = 0.005
 	dragModelType = default
@@ -30,20 +24,19 @@ PART
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 3200
-	
+
+	MODEL
+	{
+		model = CCTV/Parts/monitor/monitor
+	}
+
 	MODULE
 	{
 		name = cctv
 	}
-	MODULE
-	{
-		name = KASModuleGrab
-		evaPartPos = (0.0, 0.0, 0.0)
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize = 4
-		attachOnPart = True
-		attachOnEva = False
-		attachOnStatic = True
-	}
+}
+
+@PART[monitor]:NEEDS[BobsPanicBox]:FINAL
+{
+	-MODULE[Module_BobsExplosionDetector] {}
 }

--- a/GameData/CCTV/Parts/monitor/monitor1.cfg
+++ b/GameData/CCTV/Parts/monitor/monitor1.cfg
@@ -3,15 +3,9 @@ PART
 	name = monitor1
 	module = Part
 	author = Lunatics
-	
-	MODEL
-	{
-		// model = lunatics/monitor/monitor1
-		model = CCTV/Parts/monitor/monitor1
-	}
-	
+
 	node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
-	
+
 	TechRequired = advExploration
 	entryCost = 3200
 	cost = 3300
@@ -21,7 +15,7 @@ PART
 	manufacturer = Lunatic Aeronautics
 	description = Lunatics' second best ever TV
 	attachRules = 0,1,0,0,1
-	
+
 	// --- standard part parameters ---
 	mass = 0.005
 	dragModelType = default
@@ -30,20 +24,19 @@ PART
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 3200
-	
+
+	MODEL
+	{
+		model = CCTV/Parts/monitor/monitor1
+	}
+
 	MODULE
 	{
 		name = cctv
 	}
-	MODULE
-	{
-		name = KASModuleGrab
-		evaPartPos = (0.0, 0.0, 0.0)
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize = 4
-		attachOnPart = True
-		attachOnEva = False
-		attachOnStatic = True
-	}
+}
+
+@PART[monitor1]:NEEDS[BobsPanicBox]:FINAL
+{
+	-MODULE[Module_BobsExplosionDetector] {}
 }

--- a/GameData/CCTV/Parts/monitor/monitor2.cfg
+++ b/GameData/CCTV/Parts/monitor/monitor2.cfg
@@ -3,15 +3,9 @@ PART
 	name = monitor2
 	module = Part
 	author = Lunatics
-	
-	MODEL
-	{
-		// model = lunatics/monitor/monitor2
-		model = CCTV/Parts/monitor/monitor2
-	}
-	
+
 	node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0
-	
+
 	TechRequired = advExploration
 	entryCost = 3200
 	cost = 3300
@@ -21,7 +15,7 @@ PART
 	manufacturer = Lunatic Aeronautics
 	description = Lunatics' best ever flat TV
 	attachRules = 0,1,0,0,1
-	
+
 	// --- standard part parameters ---
 	mass = 0.005
 	dragModelType = default
@@ -30,20 +24,19 @@ PART
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 3200
-	
+
+	MODEL
+	{
+		model = CCTV/Parts/monitor/monitor2
+	}
+
 	MODULE
 	{
 		name = cctv
 	}
-	MODULE
-	{
-		name = KASModuleGrab
-		evaPartPos = (0.0, 0.0, 0.0)
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize = 4
-		attachOnPart = True
-		attachOnEva = False
-		attachOnStatic = True
-	}
+}
+
+@PART[monitor2]:NEEDS[BobsPanicBox]:FINAL
+{
+	-MODULE[Module_BobsExplosionDetector] {}
 }

--- a/GameData/CCTV/Parts/remotecam/remotecam.cfg
+++ b/GameData/CCTV/Parts/remotecam/remotecam.cfg
@@ -3,15 +3,9 @@ PART
 	name = remotecam
 	module = Part
 	author = Lunatics
-	
-	MODEL
-	{
-		//model=lunatics/remotecam/remotecam
-		model=CCTV/Parts/remotecam/remotecam
-	}
-	
+
 	node_attach = 0.0, 0.0, 0.07, 0.0, 0.0, -1.0
-	
+
 	TechRequired = advExploration
 	entryCost = 3200
 	cost = 3300
@@ -21,7 +15,7 @@ PART
 	manufacturer = Lunatic Aeronautics
 	description = A brand new wifi camera
 	attachRules = 0,1,0,0,1
-	
+
 	// --- standard part parameters ---
 	mass = 0.005
 	dragModelType = default
@@ -30,24 +24,19 @@ PART
 	angularDrag = 1
 	crashTolerance = 8
 	maxTemp = 3200
-	
+
+	MODEL
+	{
+		model=CCTV/Parts/remotecam/remotecam
+	}
+
 	MODULE
 	{
 		name = ccrcam
 		speed = 30
 		cameraBody = cambody
 	}
-	MODULE
-	{
-		name = KASModuleGrab
-		evaPartPos = (0.0, 0.0, 0.0)
-		evaPartDir = (0,0,-1)
-		storable = true
-		storedSize = 1
-		attachOnPart = True
-		attachOnEva = False
-		attachOnStatic = True
-	}
+
 	MODULE
 	{
 		name = JSIExternalCameraSelector
@@ -55,4 +44,9 @@ PART
 		rotateCamera = 0,0,0
 		cameraIDPrefix = ExtCam
 	}
+}
+
+@PART[remotecam]:NEEDS[BobsPanicBox]:FINAL
+{
+	-MODULE[Module_BobsExplosionDetector] {}
 }


### PR DESCRIPTION
1. Addresses '[Part.AddModule] Cannot find a PartModule of typename 'KASModuleGrab' by removing deprecated KASModuleGrab; it's not necessary.
2. Also adds MMConfig to not add BPB module.
3. removes lunatic/... references.